### PR TITLE
vm-size-error && tokenCanManage

### DIFF
--- a/contracts/DAO.sol
+++ b/contracts/DAO.sol
@@ -133,6 +133,8 @@ contract DAO is AccessControl {
     event UserPromotionProposed(address indexed by, address user, bytes32 toRole);
     event UserPromoted(address indexed user, bytes32 toRole);
     event UserKicked(address indexed by, address user);
+    event UserTokenAuthorization(address indexed by, address user, string token);
+    event UserTokenAuthorizationRevoked(address indexed by, address user, string token);
 
     constructor(
 
@@ -304,6 +306,14 @@ contract DAO is AccessControl {
     public isMember(msg.sender) hasPermission(DaoPermission.token_auth) canManageToken(symbol) {
         require(tokenAuthorization[_address][symbol] == false,"Address already authorized for this Token");
         tokenAuthorization[_address][symbol] = true;
+        emit UserTokenAuthorization(msg.sender, _address, symbol);
+    }
+
+    function removeTokenAuth(string memory symbol, address _address)
+    public isMember(msg.sender) hasPermission(DaoPermission.token_auth) canManageToken(symbol) {
+        require(tokenAuthorization[_address][symbol] == true,"Address already not authorized for this Token");
+        delete tokenAuthorization[_address][symbol];
+        emit UserTokenAuthorizationRevoked(msg.sender, _address, symbol);
     }
 
     function getTokenAuth(string memory tokenSymbol, address _address) public view returns (bool){

--- a/contracts/DAO.sol
+++ b/contracts/DAO.sol
@@ -49,6 +49,8 @@ contract DAO is AccessControl {
         token_mint,
         //Whether it can authorize others to use a specific token
         token_auth,
+        //Whether it can be set as authorized to manage specific tokens
+        token_canmanage,
         //Whether it can create a crowdsale
         crowd_create,
         //Whether it can join a crowdsale
@@ -159,6 +161,7 @@ contract DAO is AccessControl {
         _grantPermission(DaoPermission.token_create, OWNER_ROLE);
         _grantPermission(DaoPermission.token_mint, OWNER_ROLE);
         _grantPermission(DaoPermission.token_auth, OWNER_ROLE);
+        _grantPermission(DaoPermission.token_canmanage, OWNER_ROLE);
         _grantPermission(DaoPermission.crowd_create, OWNER_ROLE);
         _grantPermission(DaoPermission.crowd_join, OWNER_ROLE);
         _grantPermission(DaoPermission.crowd_unlock, OWNER_ROLE);
@@ -180,6 +183,7 @@ contract DAO is AccessControl {
         grantPermission(DaoPermission.token_create, ADMIN_ROLE);
         grantPermission(DaoPermission.token_mint, ADMIN_ROLE);
         grantPermission(DaoPermission.token_auth, ADMIN_ROLE);
+        grantPermission(DaoPermission.token_canmanage, ADMIN_ROLE);
         grantPermission(DaoPermission.crowd_create, ADMIN_ROLE);
         grantPermission(DaoPermission.crowd_join, ADMIN_ROLE);
         grantPermission(DaoPermission.crowd_unlock, ADMIN_ROLE);
@@ -197,6 +201,7 @@ contract DAO is AccessControl {
         //SUPERVISOR
         grantPermission(DaoPermission.token_specific, SUPERVISOR_ROLE);
         grantPermission(DaoPermission.token_transfer, SUPERVISOR_ROLE);
+        grantPermission(DaoPermission.token_canmanage, SUPERVISOR_ROLE);
         grantPermission(DaoPermission.crowd_join, SUPERVISOR_ROLE);
         grantPermission(DaoPermission.crowd_refund, SUPERVISOR_ROLE);
         grantPermission(DaoPermission.crowd_canmanage, SUPERVISOR_ROLE);
@@ -303,14 +308,15 @@ contract DAO is AccessControl {
     }
 
     function setTokenAuth(string memory symbol, address _address)
-    public isMember(msg.sender) hasPermission(DaoPermission.token_auth) canManageToken(symbol) {
+    public isMember(_address) isMember(msg.sender) hasPermission(DaoPermission.token_auth) canManageToken(symbol) {
+        require(hasPermissions(DaoPermission.token_canmanage, _address), "Target user has no permissions to be authorized for tokens");
         require(tokenAuthorization[_address][symbol] == false,"Address already authorized for this Token");
         tokenAuthorization[_address][symbol] = true;
         emit UserTokenAuthorization(msg.sender, _address, symbol);
     }
 
     function removeTokenAuth(string memory symbol, address _address)
-    public isMember(msg.sender) hasPermission(DaoPermission.token_auth) canManageToken(symbol) {
+    public isMember(_address) isMember(msg.sender) hasPermission(DaoPermission.token_auth) canManageToken(symbol) {
         require(tokenAuthorization[_address][symbol] == true,"Address already not authorized for this Token");
         delete tokenAuthorization[_address][symbol];
         emit UserTokenAuthorizationRevoked(msg.sender, _address, symbol);

--- a/test/1_DAO_test.js
+++ b/test/1_DAO_test.js
@@ -332,19 +332,6 @@ contract("DAO", (accounts) => {
                     throw new Error("Authorized Supervisor should be able to transfer a specific token for which it's authorized")
                 }
             })
-            it("Admin reverts Supervisor authorization for Token", async () => {
-                const daoInstance = await DaoContract.deployed();
-                try{
-                    await daoInstance.removeTokenAuth("EUR", supervisor, {from:admin});
-                }catch(_){
-                    throw new Error("Admin should be able to authorize a supervisor for a specific token");
-                }
-                assert.equal(
-                    await daoInstance.getTokenAuth("EUR", supervisor),
-                    true,
-                    "Supervisor shall be consider authorized for a token after being set as such by admin"
-                )
-            })
         })
         describe('Token Create', _ => {
             it("Owner can create a Token", async () => {
@@ -365,15 +352,98 @@ contract("DAO", (accounts) => {
                 }
                 return true;
             });
+            it("Supervisor can't create a Token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.createToken("Euro", "EUR", 2, "", "", 0, "", {from:supervisor});
+                }catch(_){
+                    return true;
+
+                }
+                throw new Error("Supervisor shouldn't be able to create a token");
+            });
+            it("User can't create a Token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.createToken("Euro", "EUR", 2, "", "", 0, "", {from:user});
+                }catch(_){
+                    return true;
+
+                }
+                throw new Error("User shouldn't be able to create a token");
+            });
         })
-        it("Supervisor can't authorize himself", async () => {
-            const daoInstance = await DaoContract.deployed();
-            try{
-                await daoInstance.setTokenAuth("EUR", supervisor, {from:supervisor});
-            }catch(_){
-                return true;
-            }
-            throw new Error("Supervisor shouldn't be able to authorize himself for a specific token")
+        describe("Mint Token", _ => {
+            it("Owner can mint token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                await daoInstance.mintToken("EUR", 250, {from: owner});
+            })
+            it("Admin can mint token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                await daoInstance.mintToken("EUR", 250, {from: admin});
+            })
+            it("Supervisor cannot mint token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.mintToken("EUR", 250, {from: supervisor});
+                }catch(_){
+                    return true;
+                }
+                throw new Error("Supervisor shouldn't be able to mint a token")
+            })
+            it("User cannot mint token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try {
+                    await daoInstance.mintToken("EUR", 250, {from: user});
+                }catch(_){
+                    return true;
+                }
+                throw new Error("User shouldn't be able to mint a token")
+            })
+        })
+        describe("Token Authorizations", _ => {
+            it("Supervisor can't authorize himself", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.setTokenAuth("EUR", supervisor, {from:supervisor});
+                }catch(_){
+                    return true;
+                }
+                throw new Error("Supervisor shouldn't be able to authorize himself for a specific token")
+            })
+            it("Supervisor getTokenAuth consistence (true)", async () => {
+                const daoInstance = await DaoContract.deployed();
+                assert.equal(
+                    await daoInstance.getTokenAuth("EUR", supervisor),
+                    true,
+                    "Supervisor getTokenAuth not consistent with previous assignments"
+                );
+            })
+            it("Admin reverts Supervisor authorization for Token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.removeTokenAuth("EUR", supervisor, {from:admin});
+                }catch(_){
+                    throw new Error("Admin should be able to authorize a supervisor for a specific token");
+                }
+                assert.equal(
+                    await daoInstance.getTokenAuth("EUR", supervisor),
+                    false,
+                    "Supervisor shouldn't be consider authorized for a token after being unset by admin"
+                )
+            })
+            it("User can't be authorized for tokens", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.setTokenAuth("EUR", user, {from:owner});
+                }catch(_){
+                    return true;
+                }
+                throw new Error("User shouldn't be able to be authorized for a specific token")
+            })
+            it("Owner reapplies token Authorization for Supervisor", async () => {
+
+            })
         })
     })
 });

--- a/test/1_DAO_test.js
+++ b/test/1_DAO_test.js
@@ -293,22 +293,78 @@ contract("DAO", (accounts) => {
         })
     })
     describe('Role based micro-permissions', _ => {
-        it("Owner can transfer token", async () => {
-            const daoInstance = await DaoContract.deployed();
-            await daoInstance.transferToken("EUR", 250, user);
+        describe('Token Transfer', _ => {
+            it("Owner can transfer token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                await daoInstance.transferToken("EUR", 250, user);
+            })
+            it("Admin can transfer token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                await daoInstance.transferToken("EUR", 250, user, {from:admin});
+            })
+            it("Supervisor without token auth can't transfer token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.transferToken("EUR", 250, user, {from:supervisor});
+                }catch(_){
+                    return true;
+                }
+                throw new Error("Supervisor without token auth shouldn't be able to transfer token")
+            })
+            it("Admin authorizes Supervisor for Token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.setTokenAuth("EUR", supervisor, {from:admin});
+                }catch(_){
+                    throw new Error("Admin should be able to authorize a supervisor for a specific token");
+                }
+                assert.equal(
+                    await daoInstance.getTokenAuth("EUR", supervisor),
+                    true,
+                    "Supervisor shall be consider authorized for a token after being set as such by admin"
+                )
+            })
+            it("Authorized Supervisor can transfer token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.transferToken("EUR", 250, user, {from: supervisor});
+                }catch(_){
+                    throw new Error("Authorized Supervisor should be able to transfer a specific token for which it's authorized")
+                }
+            })
+            it("Admin reverts Supervisor authorization for Token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.removeTokenAuth("EUR", supervisor, {from:admin});
+                }catch(_){
+                    throw new Error("Admin should be able to authorize a supervisor for a specific token");
+                }
+                assert.equal(
+                    await daoInstance.getTokenAuth("EUR", supervisor),
+                    true,
+                    "Supervisor shall be consider authorized for a token after being set as such by admin"
+                )
+            })
         })
-        it("Admin can transfer token", async () => {
-            const daoInstance = await DaoContract.deployed();
-            await daoInstance.transferToken("EUR", 250, user, {from:admin});
-        })
-        it("Supervisor without token auth can't transfer token", async () => {
-            const daoInstance = await DaoContract.deployed();
-            try{
-                await daoInstance.transferToken("EUR", 250, user, {from:supervisor});
-            }catch(_){
+        describe('Token Create', _ => {
+            it("Owner can create a Token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.createToken("Euro", "EUR", 2, "", "", 0, "", {from:owner});
+                }catch(_){
+                    throw new Error("Owner should be able to create a token");
+                }
                 return true;
-            }
-            throw new Error("Supervisor without token auth shouldn't be able to transfer token")
+            });
+            it("Admin can create a Token", async () => {
+                const daoInstance = await DaoContract.deployed();
+                try{
+                    await daoInstance.createToken("Euro", "EUR", 2, "", "", 0, "", {from:admin});
+                }catch(_){
+                    throw new Error("Admin should be able to create a token");
+                }
+                return true;
+            });
         })
         it("Supervisor can't authorize himself", async () => {
             const daoInstance = await DaoContract.deployed();
@@ -318,27 +374,6 @@ contract("DAO", (accounts) => {
                 return true;
             }
             throw new Error("Supervisor shouldn't be able to authorize himself for a specific token")
-        })
-        it("Admin authorizes Supervisor for Token", async () => {
-            const daoInstance = await DaoContract.deployed();
-            try{
-                await daoInstance.setTokenAuth("EUR", supervisor, {from:admin});
-            }catch(_){
-                throw new Error("Admin should be able to authorize a supervisor for a specific token");
-            }
-            assert.equal(
-                await daoInstance.getTokenAuth("EUR", supervisor),
-                true,
-                "Supervisor shall be consider authorized for a token after being set as such by admin"
-            )
-        })
-        it("Authorized Supervisor can transfer token", async () => {
-            const daoInstance = await DaoContract.deployed();
-            try{
-                await daoInstance.transferToken("EUR", 250, user, {from: supervisor});
-            }catch(_){
-                throw new Error("Authorized Supervisor should be able to transfer a specific token for which it's authorized")
-            }
         })
     })
 });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -113,13 +113,13 @@ module.exports = {
     solc: {
       version: "0.8.19",      // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-      // settings: {          // See the solidity docs for advice about optimization and evmVersion
-      //  optimizer: {
-      //    enabled: false,
-      //    runs: 200
-      //  },
-      //  evmVersion: "byzantium"
-      // }
+       settings: {          // See the solidity docs for advice about optimization and evmVersion
+        optimizer: {
+          enabled: true,
+          runs: 200
+        },
+        evmVersion: "byzantium"
+      }
     }
   },
 


### PR DESCRIPTION
By adding more functionalities to the given DAO contract, we encountered a size limit imposed by the Ethereum Mainnet that prevented solc to compile our contract, so I fixed it by passing optimization parameters to the compiler.
token_canManage permission has been added to allow users to be set as token managers.